### PR TITLE
move allowed build reasons

### DIFF
--- a/ado_downloader/__main__.py
+++ b/ado_downloader/__main__.py
@@ -445,7 +445,7 @@ def select_pipeline_run(
 ) -> int:
     az_command = shutil.which("az")
     pipeline = artifact_sources["pipelines"][pipeline_name]
-    allowed_build_reasons = artifact_sources["allowedBuildReasons"]
+    allowed_build_reasons = artifact_sources.get("allowedBuildReasons")
 
     ado_org = artifact_sources["defaults"]["ado-org"]
     ado_project = artifact_sources["defaults"]["ado-project"]
@@ -513,8 +513,9 @@ def select_pipeline_run(
             patterns: Sequence[typing.Pattern[str]], br: Dict[str, Any]
         ) -> bool:
 
-            if br["reason"] not in allowed_build_reasons:
-                return False
+            if allowed_build_reasons is not None and \
+                br["reason"] not in allowed_build_reasons:
+                    return False
 
             if patterns:
                 for pattern in patterns:

--- a/ado_downloader/__main__.py
+++ b/ado_downloader/__main__.py
@@ -514,8 +514,8 @@ def select_pipeline_run(
         ) -> bool:
 
             if allowed_build_reasons is not None and \
-                br["reason"] not in allowed_build_reasons:
-                    return False
+                    br["reason"] not in allowed_build_reasons:
+                return False
 
             if patterns:
                 for pattern in patterns:

--- a/ado_downloader/__main__.py
+++ b/ado_downloader/__main__.py
@@ -445,6 +445,7 @@ def select_pipeline_run(
 ) -> int:
     az_command = shutil.which("az")
     pipeline = artifact_sources["pipelines"][pipeline_name]
+    allowed_build_reasons = artifact_sources["allowedBuildReasons"]
 
     ado_org = artifact_sources["defaults"]["ado-org"]
     ado_project = artifact_sources["defaults"]["ado-project"]
@@ -511,14 +512,8 @@ def select_pipeline_run(
         def matches_needs(
             patterns: Sequence[typing.Pattern[str]], br: Dict[str, Any]
         ) -> bool:
-            ALLOWED_BUILD_REASONS = [
-                "batchedCI",
-                "individualCI",
-                "manual",
-                "buildCompletion",
-            ]
 
-            if br["reason"] not in ALLOWED_BUILD_REASONS:
+            if br["reason"] not in allowed_build_reasons:
                 return False
 
             if patterns:


### PR DESCRIPTION
This PR works with the updated `ado-download.yaml` for yocto. The updated allowed build reasons is move to the yaml file.